### PR TITLE
Delete old phar, otherwise contents get appended to the old phar

### DIFF
--- a/app/PharBuilder.php
+++ b/app/PharBuilder.php
@@ -134,7 +134,9 @@ class PharBuilder
         $this->output->writeln(' <info>OK</info>');
 
         // Unlink, otherwise we just add things to the already existing phar
-        unlink($this->pharName);
+        if (file_exists($this->pharName)) {
+            unlink($this->pharName);
+        }
 
         $this->phar = new \Phar(
             $this->pharName,

--- a/app/PharBuilder.php
+++ b/app/PharBuilder.php
@@ -133,6 +133,9 @@ class PharBuilder
         $dirsFiles = $this->readComposerAutoload();
         $this->output->writeln(' <info>OK</info>');
 
+        // Unlink, otherwise we just add things to the already existing phar
+        unlink($this->pharName);
+
         $this->phar = new \Phar(
             $this->pharName,
             \FilesystemIterator::CURRENT_AS_FILEINFO | \FilesystemIterator::KEY_AS_FILENAME,


### PR DESCRIPTION
e.g. first build with `--include-dev`, then without `--include-dev`. The `.phar` will be the exact same size, because we're always just appending / overwriting old files.
