### PR TITLE
Check if the current directory have a composer.json [ #13 ]

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ _Extract from the `vendor/bin/phar-builder help package` command_
 
 ```
 Usage:
-  package [options] [--] <composer>
+  package [options] [--] [<composer>]
 
 Arguments:
-  composer                       The path to the composer.json
+  composer                       The path to the composer.json. If the argument is not provided, it will look for a composer.json file in the current directory
 
 Options:
       --include-dev              Include development packages and path

--- a/app/Commands/Base.php
+++ b/app/Commands/Base.php
@@ -89,8 +89,9 @@ abstract class Base extends Command
         if (!file_exists($value) || !is_file($value) || 'composer.json' !== basename($value)) {
             $this->getApplication()->renderException(
                 new \InvalidArgumentException(
-                    'The path provided is not a valid <option=bold>composer.json</option=bold> file' . PHP_EOL .
-                    '  Path: ' . $value
+                    'The path provided is not a valid <option=bold>composer.json</option=bold> file,' . PHP_EOL .
+                    'or the current directory does not contain a <option=bold>composer.json</option=bold> file.' .
+                    PHP_EOL . '  Path: ' . $value
                 ),
                 $output
             );

--- a/app/Commands/Package.php
+++ b/app/Commands/Package.php
@@ -34,7 +34,14 @@ class Package extends Base
     protected function configure()
     {
         $this->setName('package')
-            ->addArgument('composer', InputArgument::REQUIRED, 'The path to the composer.json')
+            ->addArgument(
+                'composer',
+                InputArgument::OPTIONAL,
+                //@codingStandardsIgnoreStart
+                'The path to the composer.json. If the argument is not provided, ' .
+                'it will look for a composer.json file in the current directory'
+                 //@codingStandardsIgnoreEnd
+            )
             ->addOption('include-dev', '', InputOption::VALUE_NONE, 'Include development packages and path')
             ->addOption('entry-point', 'e', InputOption::VALUE_REQUIRED, 'Your application start file')
             ->addOption(
@@ -97,6 +104,9 @@ CODE
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $composerFile = $input->getArgument('composer');
+        if (null === $composerFile) {
+            $composerFile = getcwd() . DIRECTORY_SEPARATOR . 'composer.json';
+        }
 
         $this->validateComposer($composerFile, $output);
 


### PR DESCRIPTION
- Make the argument not required.
- Update usage
- Update readme
- If the argument not provided check of a `composer.json` in the current directory
- Update the error message is the `composer.json` is invalid
