### PR TITLE
Fix for incorrect stub and file names on Windows

### DIFF
--- a/app/PharBuilder.php
+++ b/app/PharBuilder.php
@@ -353,7 +353,7 @@ class PharBuilder
 
         $this->stubFile = $this->makePathRelative($this->stubFile);
         $this->phar->setStub(
-            (!$this->isSkipShebang() ? '#!/usr/bin/env php' . PHP_EOL : '') .
+            (!$this->isSkipShebang() ? '#!/usr/bin/env php' . "\n" : '') .
             '<?php Phar::mapPhar(); include "phar://' . $this->alias . '/' . $this->stubFile .
             '"; __HALT_COMPILER(); ?>'
         );

--- a/app/PharBuilder.php
+++ b/app/PharBuilder.php
@@ -455,7 +455,7 @@ class PharBuilder
              *
              * @var \Symfony\Component\Finder\SplFileInfo $file
              */
-            $this->addFile(realpath($directory . DIRECTORY_SEPARATOR . $file->getRelativePathname()));
+            $this->addFile(rtrim($directory, '\/') . DIRECTORY_SEPARATOR . $file->getRelativePathname());
         }
     }
 

--- a/app/PharBuilder.php
+++ b/app/PharBuilder.php
@@ -455,7 +455,7 @@ class PharBuilder
              *
              * @var \Symfony\Component\Finder\SplFileInfo $file
              */
-            $this->addFile($directory . DIRECTORY_SEPARATOR . $file->getRelativePathname());
+            $this->addFile(realpath($directory . DIRECTORY_SEPARATOR . $file->getRelativePathname()));
         }
     }
 


### PR DESCRIPTION
On Windows it fails due to dirs separator mixing (1) and compiled phar don't work due to \r\n at the end of first line (2):

Original behavior
-------------------
```
phar-builder package composer.json -vvv

 [WARNING] Your version on PHP is not compiled with the flag "--enable-pcntl".

           Unix interruption will not work

Creating your Phar application...
=================================

Reading composer.json...
------------------------

 [OK] composer.json analysed

Adding files to Phar...
-----------------------

string(14) "AddCommand.php"
[2K > src/\AddCommand.php

  [BadMethodCallException]
  Entry src//AddCommand.php does not exist and cannot be created: phar error: in
  valid path "src//AddCommand.php" contains double slash


Exception trace:
 () at C:\Users\wapmo\AppData\Roaming\Composer\vendor\macfja\phar-builder\app\PharBuilder.php:482
 Phar->addFile() at C:\Users\wapmo\AppData\Roaming\Composer\vendor\macfja\phar-builder\app\PharBuilder.php:482
 MacFJA\PharBuilder\PharBuilder->addFile() at C:\Users\wapmo\AppData\Roaming\Composer\vendor\macfja\phar-builder\app\PharBuilder.php:430
 MacFJA\PharBuilder\PharBuilder->addDir() at C:\Users\wapmo\AppData\Roaming\Composer\vendor\macfja\phar-builder\app\PharBuilder.php:337
 MacFJA\PharBuilder\PharBuilder->buildPhar() at C:\Users\wapmo\AppData\Roaming\Composer\vendor\macfja\phar-builder\app\Commands\Package.php:144
...

package [--include-dev] [-e|--entry-point ENTRY-POINT] [--compression COMPRESSION] [-f|--no-compression] [-z|--gzip] [-b|--bzip2] [--name NAME] [-o|--output-dir OUTPUT-DIR] [-i|--include INCLUDE] [--] [<composer>]
```

After result
------------
Package successfully created.
