### PR TITLE
Fix #36 - Change file content in memory and write it only in phar

### DIFF
--- a/app/Utils/Composer.php
+++ b/app/Utils/Composer.php
@@ -206,14 +206,14 @@ class Composer
      *
      * @param string[] $packageNames List of the packages name
      *
-     * @return void
+     * @return string|null
      *
      * @throws \RuntimeException
      */
-    public function removeFilesAutoloadFor($packageNames)
+    public function getRemoveFilesAutoloadFor($packageNames)
     {
         if (0 === count($packageNames)) {
-            return;
+            return null;
         }
 
         $autoloadFile = $this->getVendorDir() . DIRECTORY_SEPARATOR .
@@ -230,7 +230,7 @@ class Composer
             }
         }
 
-        file_put_contents($autoloadFile, $content);
+        return $content;
     }
 
     /**


### PR DESCRIPTION
Make the change only on a variable (in memory) and apply this change only on the phar version of the file.

It avoid to change your actual composer autoload