### PR TITLE
Path resolving issues fixes

### DIFF
--- a/app/PharBuilder.php
+++ b/app/PharBuilder.php
@@ -20,6 +20,11 @@ use webignition\ReadableDuration\ReadableDuration;
 class PharBuilder
 {
     /**
+     * Character list of directory separators
+     */
+    const DIRECTORY_SEPARATORS = '/\\';
+
+    /**
      * The Phar object
      *
      * @var \Phar
@@ -122,7 +127,7 @@ class PharBuilder
      */
     public function setOutputDir($directory)
     {
-        $this->pharName = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . basename($this->pharName);
+        $this->pharName = rtrim($directory, self::DIRECTORY_SEPARATORS) . DIRECTORY_SEPARATOR . basename($this->pharName);
     }
 
     /**
@@ -441,7 +446,7 @@ class PharBuilder
             $exclude = rtrim($exclude, DIRECTORY_SEPARATOR);
         }
 
-        $directory = rtrim($directory, DIRECTORY_SEPARATOR);
+        $directory = rtrim($directory, self::DIRECTORY_SEPARATORS);
         $files     = Finder::create()->files()
             ->ignoreVCS(true)//Remove VCS
             ->ignoreDotFiles(true)//Remove system hidden file
@@ -464,7 +469,7 @@ class PharBuilder
              *
              * @var \Symfony\Component\Finder\SplFileInfo $file
              */
-            $this->addFile(rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $file->getRelativePathname());
+            $this->addFile(rtrim($directory, self::DIRECTORY_SEPARATORS) . DIRECTORY_SEPARATOR . $file->getRelativePathname());
         }
     }
 
@@ -500,7 +505,7 @@ class PharBuilder
 
         if (0 === strpos($path, getcwd())) {
             $path = substr($path, strlen(getcwd()));
-            $path = ltrim($path, DIRECTORY_SEPARATOR);
+            $path = ltrim($path, self::DIRECTORY_SEPARATORS);
         }
 
         return $path;

--- a/app/PharBuilder.php
+++ b/app/PharBuilder.php
@@ -496,12 +496,32 @@ class PharBuilder
      */
     protected function makePathRelative($path)
     {
+        $path = $this->processDotNotatedPath($path);
+
         if (0 === strpos($path, getcwd())) {
             $path = substr($path, strlen(getcwd()));
             $path = ltrim($path, DIRECTORY_SEPARATOR);
         }
 
         return $path;
+    }
+
+    /**
+     * Process dot notated relative paths
+     *
+     * @param string $path The path to resolve when it's a dot notated path (e.g. ./entry-file.php)
+     *
+     * @return string
+     */
+    protected function processDotNotatedPath($path)
+    {
+        if (preg_match('~^\.\.?[\\\/]~', $path) !== 1) {
+            return $path;
+        }
+
+        $resolvedPath = realpath(getcwd() . '/' . $path);
+
+        return $resolvedPath;
     }
 
     /**


### PR DESCRIPTION
Windows allows for both `/` and `\` as directory separators. An example where this is often done is the composer autoload directive, e.g.:

    "autoload": {
        "psr-4": {
            "SomeVendor\\PackageName\\": "src/"
        },
        "files": ["src/functions.php"]
    },

It seems like this project doesn't properly handle these because it uses the system dependent `DIRECTORY_SEPARATOR` constant to trim paths. Which will always return `\` on Windows leaving some paths not properly stripped.

https://github.com/MacFJA/PharBuilder/commit/f04691108a253a37cde7b16c736df6441d5cb180 fixes this.

Another fix in this PR makes sure the "entry-point" example in the readme actually works:

    "entry-point": "./index.php",

When I ran a build using that (on my Windows machine) I ended up with a directory `.` in the phar with only underneath it the entry-point script. Which meant when trying t run the phar it failed because it couldn't find the entry file.

https://github.com/MacFJA/PharBuilder/commit/bd632498e4875162a63382d355a4c334d2c34044 fixes this issue.

