### PR TITLE
Include composer.json in builds

### DIFF
--- a/app/PharBuilder.php
+++ b/app/PharBuilder.php
@@ -443,7 +443,7 @@ class PharBuilder
         $files     = Finder::create()->files()
             ->ignoreVCS(true)//Remove VCS
             ->ignoreDotFiles(true)//Remove system hidden file
-            ->notName('composer.*')//Remove composer configuration
+            ->notName('composer.lock')//Remove composer configuration
             ->notName('*~')//Remove backup file
             ->notName('*.back')//Remove backup file
             ->notName('*.swp')//Remove backup file


### PR DESCRIPTION
Some dependencies require their composer.json file available. An example of this is cakephp/phinx which tries to get the version from the composer file and fatals if the file is not available.

I only included `composer.json` in the builds instead of including both `composer.json` and `composer.lock` which is for now sufficient for me.

To address the concerns raised in #50 I did a quick test to see what difference in file size this would result in for the php-cs-fixer project. The size difference (for that specific project) would be an increase of 0.02MB which imho hardly is something to be worried about.

Closes #50 